### PR TITLE
Relax application_name requirement to allow killing by mdb_admin (PG17)

### DIFF
--- a/src/backend/storage/ipc/signalfuncs.c
+++ b/src/backend/storage/ipc/signalfuncs.c
@@ -96,7 +96,7 @@ pg_signal_backend(int pid, int sig)
 
 			if (!((local_beentry && local_beentry->backendStatus.st_backendType == B_AUTOVAC_WORKER && 
 				has_privs_of_role(GetUserId(), ROLE_PG_SIGNAL_AUTOVACUUM))
-				|| (appname != NULL && strcmp(appname, "MDB") == 0)))
+				|| (appname != NULL && strncmp(appname, "MDB", 3) == 0)))
 					return SIGNAL_BACKEND_NOSUPERUSER;
 		} else {
 			if (superuser_arg(proc->roleId))


### PR DESCRIPTION
MDB-40410: Allow to kill backends which have application_name starting with "MDB" instead of exactly matching