### PR TITLE
Relax application_name requirement to allow killing by mdb_admin (PG16)

### DIFF
--- a/src/backend/storage/ipc/signalfuncs.c
+++ b/src/backend/storage/ipc/signalfuncs.c
@@ -106,7 +106,7 @@ pg_signal_backend(int pid, int sig)
 		/* mdb admin allowed to kill proc with application name 'MDB' or autovacuum */
 		if (local_beentry->backendStatus.st_backendType == B_AUTOVAC_WORKER) {
 			// ok
-		} else if (appname != NULL && strcmp(appname, "MDB") == 0) {
+		} else if (appname != NULL && strncmp(appname, "MDB", 3) == 0) {
 			// ok
 		} else {
 			return SIGNAL_BACKEND_NOSUPERUSER;


### PR DESCRIPTION
MDB-40410: Allow to kill backends which have application_name starting with "MDB" instead of exactly matching