### PR TITLE
Allow canceling service queries.

### DIFF
--- a/src/backend/storage/ipc/signalfuncs.c
+++ b/src/backend/storage/ipc/signalfuncs.c
@@ -53,8 +53,10 @@ pg_signal_backend(int pid, int sig)
 {
 	PGPROC	   *proc = BackendPidGetProc(pid);
 	LocalPgBackendStatus *local_beentry;
+	bool			ok;
 
 	local_beentry = NULL;
+	ok = false;
 
 	/*
 	 * BackendPidGetProc returns NULL if the pid isn't valid; but by the time
@@ -89,7 +91,28 @@ pg_signal_backend(int pid, int sig)
 	 *
 	 * Otherwise, users can signal backends for roles they have privileges of.
 	 */
-	if (!OidIsValid(proc->roleId) || superuser_arg(proc->roleId))
+
+	/* We allow to kill queries issued with MDB prefix */
+	if (!superuser() && !OidIsValid(proc->roleId))
+	{
+		LocalPgBackendStatus *local_beentry;
+		char * appname = NULL;
+		local_beentry = pgstat_get_local_beentry_by_proc_number(GetNumberFromPGProc(proc));
+
+		if (local_beentry != NULL)
+		{
+			appname = local_beentry->backendStatus.st_appname;
+			if (appname != NULL && strncmp(appname, "MDB", 3) == 0)
+				ok = true;
+		}
+	}
+
+	if (ok)
+	{
+		/* This code style is not very conventional, but for sake of rebase, we code it like this */
+		;
+	}
+	else if (!OidIsValid(proc->roleId) || superuser_arg(proc->roleId))
 	{
 		ProcNumber	procNumber = GetNumberFromPGProc(proc);
 		BackendType backendType = pgstat_get_backend_type_by_proc_number(procNumber);


### PR DESCRIPTION
Allow user to cancel backend which is explicitly marked as service operation, allowed to be canceled. We check `application_name` for containing MDB prefix